### PR TITLE
Added abstract section to pod

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,14 @@
-2009-11-25    <oliver.g.charles@googlemail.com>
+Revision history for Perl module SQL::Abstract::Plugin::InsertReturning
 
-	* InsertReturning.pm: First version
+0.06 2014-03-
+
+    - Added an abstract, which is also flags as deprecated
+
+0.05 2010-03-10
+
+    - Deprecated
+
+0.01 2009-11-25    <oliver.g.charles@googlemail.com>
+
+	- InsertReturning.pm: First version
 

--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for Perl module SQL::Abstract::Plugin::InsertReturning
 0.06 2014-03-
 
     - Added an abstract, which is also flags as deprecated
+    - Added [GithubMeta] to dist.ini, so github repo listed in dist metadata
 
 0.05 2010-03-10
 

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name = SQL-Abstract-Plugin-InsertReturning
-version = 0.05
+version = 0.06
 author = Oliver Charles <oliver.g.charles@googlemail.com>
 license = Artistic_2_0
 copyright_holder = Oliver Charles

--- a/dist.ini
+++ b/dist.ini
@@ -13,3 +13,4 @@ Sub::Exporter = 0.9
 
 [Git::Tag]
 [Git::Push]
+[GithubMeta]

--- a/lib/SQL/Abstract/Plugin/InsertReturning.pm
+++ b/lib/SQL/Abstract/Plugin/InsertReturning.pm
@@ -12,6 +12,10 @@ use Sub::Exporter -setup => {
     }
 };
 
+=head1 NAME
+
+SQL::Abstract::Plugin::InsertReturning - (DEPRECATED) Augment SQL::Abstract->insert with support for returning data
+
 =head1 SYNOPSIS
 
     use SQL::Abstract;


### PR DESCRIPTION
Hi,

I added an abstract section to the pod. MetaCPAN and search.cpan.org both expect to find this, and without it they don't present the module in the usual way.

I marked the module as deprecated in the abstract, so having an abstract will make this more clear in search results.

You could also consider putting a note in the doc saying that you'll remove all copies of this dist from CPAN at some date later this year. Or you could do that now, since it's been 4 years since you deprecated the module?

Cheers,
Neil
